### PR TITLE
Change path for getcert command in certmonger_certificate provider

### DIFF
--- a/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
+++ b/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
@@ -2,7 +2,7 @@ Puppet::Type.type(:certmonger_certificate).provide :certmonger_certificate do
   desc 'Provider for certmonger certificates.'
 
   confine exists: '/usr/sbin/certmonger'
-  commands getcert: '/bin/getcert'
+  commands getcert: '/usr/bin/getcert'
 
   mk_resource_methods
 


### PR DESCRIPTION
This path was valid for CentOS, but doesn't work in Debian. It seems
that it will work for both by getting the getcert command from /usr/bin
instead of /bin. So this addresses issue #8.