### PR TITLE
Use Puppet 4 types

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,5 @@
 fixtures:
   symlinks:
     certmonger: "#{source_dir}"
+  repositories:
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"

--- a/manifests/request_ipa_cert.pp
+++ b/manifests/request_ipa_cert.pp
@@ -1,64 +1,62 @@
-# define: certmonger::request_ipa_cert
+# == Define: certmonger::request_ipa_cert
+#
 # Request a new certificate from IPA (via certmonger) using a puppet define
 #
-# # Parameters:
-# * `certfile`    (required; String) - Full path of certificate to be managed by certmonger. e.g. `/path/to/certificate.crt`
-# * `keyfile`     (required; String) - Full path to private key file to be manaegd by certmonger. e.g. `/path/to/key.pem`
-# * `keysize`     (optional; String) - Generate keys with a specific keysize in bits. e.g. `4096`
-# * `hostname`    (optional; String) - Hostname to use (appears in subject field of cert). e.g. `webserver.example.com`
-# * `principal`   (optional; String) - IPA service principal certmonger should use when requesting cert.
-#                                      e.g. `HTTP/webserver.example.com`.
-# * `dns`         (optional; String or Array) - DNS subjectAltNames to be present in the certificate request.
-#                                      Can be a string (use commas or spaces to separate values) or an array.
-#                                      e.g. `ssl.example.com webserver01.example.com`
-#                                      e.g. `ssl.example.com, webserver01.example.com`
-#                                      e.g. `["ssl.example.com","webserver01.example.com"]`
-# * `eku`         (optional; String or Array) - Extended Key Usage attributes to be present in the certificate request.
-#                                      Can be a string (use commas or spaces to separate values) or an array.
-#                                      e.g. `id-kp-clientAuth id-kp-serverAuth`
-#                                      e.g. `id-kp-clientAuth, id-kp-serverAuth`
-#                                      e.g. `["id-kp-clientAuth","id-kp-serverAuth"]`
-# * `usage`       (optional; String or Array) - Key Usage attributes to be present in the certificate request.
-#                                      Can be a string (use commas or spaces to separate values) or an array.
-#                                      e.g. `digitalSignature nonRepudiation keyEncipherment`
-#                                      e.g. `digitalSignature, nonRepudiation, keyEncipherment`
-#                                      e.g. `["digitalSignature", "nonRepudiation", "keyEncipherment"]`
-# * `presavecmd`  (optional; String) - Command certmonger should run before saving the certificate
-# * `postsavecmd` (optional; String) - Command certmonger should run after saving the certificate
-# * `cacertfile`  (optional; String) - Ask certmonger to save the CA's certificate to this path. eg. `/path/to/ca.crt`
-# * `profile`     (optional; String) - Ask the CA to process request using the named profile. e.g. `caIPAserviceCert`
-# * `issuer`      (optional; String) - Ask the CA to process the request using the named issuer. e.g. `ca-puppet`
-# * `issuerdn`    (optional; String) - If a specific issuer is needed, provide the issuer DN. e.g. `CN=Puppet CA`
+# === Parameters
+#
+# $certfile::     Full path of certificate to be managed by certmonger. e.g. `/path/to/certificate.crt`
+# $keyfile::      Full path to private key file to be manaegd by certmonger. e.g. `/path/to/key.pem`
+# $keysize::      Generate keys with a specific keysize in bits. e.g. `4096`
+# $hostname::     Hostname to use (appears in subject field of cert). e.g. `webserver.example.com`
+# $principal::    IPA service principal certmonger should use when requesting cert.
+#                 e.g. `HTTP/webserver.example.com`.
+# $dns::          DNS subjectAltNames to be present in the certificate request.
+#                 Can be a string (use commas or spaces to separate values) or an array.
+#                 e.g. `ssl.example.com webserver01.example.com`
+#                 e.g. `ssl.example.com, webserver01.example.com`
+#                 e.g. `["ssl.example.com","webserver01.example.com"]`
+# $eku::          Extended Key Usage attributes to be present in the certificate request.
+#                 Can be a string (use commas or spaces to separate values) or an array.
+#                 e.g. `id-kp-clientAuth id-kp-serverAuth`
+#                 e.g. `id-kp-clientAuth, id-kp-serverAuth`
+#                 e.g. `["id-kp-clientAuth","id-kp-serverAuth"]`
+# $usage::        Key Usage attributes to be present in the certificate request.
+#                 Can be a string (use commas or spaces to separate values) or an array.
+#                 e.g. `digitalSignature nonRepudiation keyEncipherment`
+#                 e.g. `digitalSignature, nonRepudiation, keyEncipherment`
+#                 e.g. `["digitalSignature", "nonRepudiation", "keyEncipherment"]`
+# $presavecmd::   Command certmonger should run before saving the certificate
+# $postsavecmd::  Command certmonger should run after saving the certificate
+# $cacertfile::   Ask certmonger to save the CA's certificate to this path. eg. `/path/to/ca.crt`
+# $profile::      Ask the CA to process request using the named profile. e.g. `caIPAserviceCert`
+# $issuer::       Ask the CA to process the request using the named issuer. e.g. `ca-puppet`
+# $issuerdn::     If a specific issuer is needed, provide the issuer DN. e.g. `CN=Puppet CA`
 #
 define certmonger::request_ipa_cert (
-  $certfile,
-  $keyfile,
-  $keysize     = undef,
-  $hostname    = undef,
-  $principal   = undef,
-  $dns         = undef,
-  $eku         = undef,
-  $usage       = undef,
-  $presavecmd  = undef,
-  $postsavecmd = undef,
-  $profile     = undef,
-  $cacertfile  = undef,
-  $issuer      = undef,
-  $issuerdn    = undef,
+  Stdlib::Absolutepath                  $certfile,
+  Stdlib::Absolutepath                  $keyfile,
+  Variant[Integer[2048], String, Undef] $keysize     = undef,
+  Optional[String]                      $hostname    = undef,
+  Optional[String]                      $principal   = undef,
+  Variant[Array[String], String, Undef] $dns         = undef,
+  Variant[Array[String], String, Undef] $eku         = undef,
+  Variant[Array[String], String, Undef] $usage       = undef,
+  Optional[String]                      $presavecmd  = undef,
+  Optional[String]                      $postsavecmd = undef,
+  Optional[String]                      $profile     = undef,
+  Optional[Stdlib::Absolutepath]        $cacertfile  = undef,
+  Optional[String]                      $issuer      = undef,
+  Optional[String]                      $issuerdn    = undef,
 ) {
   include ::certmonger
   include ::certmonger::scripts
-
-  validate_string($certfile, $keyfile)
-  validate_absolute_path($certfile)
-  validate_absolute_path($keyfile)
 
   $options = "-f ${certfile} -k ${keyfile}"
   $options_certfile = "-f ${certfile}"
 
   if $keysize {
     $options_keysize = "-g ${keysize}"
-  else {
+  } else {
     $options_keysize = ''
   }
 
@@ -79,16 +77,14 @@ define certmonger::request_ipa_cert (
   }
 
   if $dns {
-    if is_array($dns) {
-      $options_dns_joined = join($dns, ' -D ')
-      $dns_csv = join($dns, ',')
-    } elsif is_string($dns) {
-      $dns_array = split(regsubst(strip($dns),'[ ,]+',','), ',')
-      $options_dns_joined = join($dns_array, ' -D ')
-      $dns_csv = join($dns_array, ',')
+    if $dns =~ String {
+      $dns_array = split(regsubst(strip($dns),'[ ,]+', ',', 'G'), ',')
     } else {
-      fail('certmonger::request_ipa_cert: dns parameter must be either a string or array.')
+      $dns_array = $dns
     }
+    $options_dns_joined = join($dns_array, ' -D ')
+    $dns_csv = join($dns_array, ',')
+
     $options_dns = regsubst($options_dns_joined, '^', '-D ')
     $options_dns_csv = "-D ${dns_csv}"
   } else {
@@ -97,16 +93,15 @@ define certmonger::request_ipa_cert (
   }
 
   if $usage {
-    if is_array($usage) {
-      $options_usage_joined = join($usage, ' -u ')
-      $usage_csv = join($usage, ',')
-    } elsif is_string($usage) {
-      $usage_array = split(regsubst(strip($usage),'[ ,]+',','), ',')
-      $options_usage_joined = join($usage_array, ' -u ')
-      $usage_csv = join($usage_array, ',')
+    if $usage =~ String {
+      $usage_array = split(regsubst(strip($usage),'[ ,]+', ',', 'G'), ',')
     } else {
-      fail('certmonger::request_ipa_cert: usage parameter must be either a string or array.')
+      $usage_array = $usage
     }
+
+    $options_usage_joined = join($usage_array, ' -u ')
+    $usage_csv = join($usage_array, ',')
+
     $options_usage = regsubst($options_usage_joined, '^', '-u ')
     $options_usage_csv = "-u ${usage_csv}"
   } else {
@@ -115,16 +110,15 @@ define certmonger::request_ipa_cert (
   }
 
   if $eku {
-    if is_array($eku) {
-      $options_eku_joined = join($eku, ' -U ')
-      $eku_csv = join($eku, ',')
-    } elsif is_string($eku) {
-      $eku_array = split(regsubst(strip($eku),'[ ,]+',','), ',')
-      $options_eku_joined = join($eku_array, ' -U ')
-      $eku_csv = join($eku_array, ',')
+    if $eku =~ String {
+      $eku_array = split(regsubst(strip($eku),'[ ,]+', ',', 'G'), ',')
     } else {
-      fail('certmonger::request_ipa_cert: eku parameter must be either a string or array.')
+      $eku_array = $eku
     }
+
+    $options_eku_joined = join($eku_array, ' -U ')
+    $eku_csv = join($eku_array, ',')
+
     $options_eku = regsubst($options_eku_joined, '^', '-U ')
     $options_eku_csv = "-U ${eku_csv}"
   } else {

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "description": "Certmonger puppet module for integration with IPA CAs",
   "tags": ["certmonger", "ipa", "ca","ipa-getcert","freeipa"],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 2.4.0 < 5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.13.0 < 5.0.0"}
   ],
   "operatingsystem_support": [
     {

--- a/spec/defines/request_ipa_cert_spec.rb
+++ b/spec/defines/request_ipa_cert_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe 'certmonger::request_ipa_cert' do
+  let :title do
+    'apache'
+  end
+
+  let :params do
+    {
+      :certfile => '/tmp/server.crt',
+      :keyfile  => '/tmp/server.key',
+    }.merge(extra_params)
+  end
+
+  context 'with minimal parameters' do
+    let :extra_params do
+      {}
+    end
+
+    command = "rm -rf /tmp/server.key /tmp/server.crt ; mkdir -p `dirname /tmp/server.key` `dirname /tmp/server.crt` ;
+                    ipa-getcert stop-tracking -f /tmp/server.crt ;
+                    ipa-getcert request -f /tmp/server.crt -k /tmp/server.key               "
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_exec('ipa-getcert-request-/tmp/server.crt').with_command(command) }
+  end
+
+  context 'with strings' do
+    let :extra_params do
+      {
+        :keysize     => '4096',
+        :hostname    => 'myhost.example.com',
+        :principal   => 'HTTP/myhost.example.com',
+        :dns         => 'www.example.com,myhost.example.com',
+        :eku         => 'id-kp-clientAuth, id-kp-serverAuth',
+        :usage       => 'digitalSignature nonRepudiation keyEncipherment',
+        :presavecmd  => '/bin/systemctl stop httpd',
+        :postsavecmd => '/bin/systemctl start httpd',
+        :cacertfile  => '/path/to/ca.crt',
+        :profile     => 'caIPAserviceCert',
+        :issuer      => 'ca-puppet',
+        :issuerdn    => 'CA=Puppet CA',
+      }
+    end
+
+    command = "rm -rf /tmp/server.key /tmp/server.crt ; mkdir -p `dirname /tmp/server.key` `dirname /tmp/server.crt` ;
+                    ipa-getcert stop-tracking -f /tmp/server.crt ;
+                    ipa-getcert request -f /tmp/server.crt -k /tmp/server.key -g 4096 -N CN=myhost.example.com -K HTTP/myhost.example.com -D www.example.com -D myhost.example.com -F '/path/to/ca.crt'     -u digitalSignature -u nonRepudiation -u keyEncipherment -U id-kp-clientAuth -U id-kp-serverAuth -X 'ca-puppet' -T 'caIPAserviceCert' -B '/bin/systemctl stop httpd' -C '/bin/systemctl start httpd'"
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_exec('ipa-getcert-request-/tmp/server.crt').with_command(command) }
+  end
+
+  context 'with arrays' do
+    let :extra_params do
+      {
+        :keysize     => 4096,
+        :hostname    => 'myhost.example.com',
+        :principal   => 'HTTP/myhost.example.com',
+        :dns         => ['www.example.com', 'myhost.example.com'],
+        :eku         => ['id-kp-clientAuth', 'id-kp-serverAuth'],
+        :usage       => ['digitalSignature', 'nonRepudiation', 'keyEncipherment'],
+        :presavecmd  => '/bin/systemctl stop httpd',
+        :postsavecmd => '/bin/systemctl start httpd',
+        :cacertfile  => '/path/to/ca.crt',
+        :profile     => 'caIPAserviceCert',
+        :issuer      => 'ca-puppet',
+        :issuerdn    => 'CA=Puppet CA',
+      }
+    end
+
+    command = "rm -rf /tmp/server.key /tmp/server.crt ; mkdir -p `dirname /tmp/server.key` `dirname /tmp/server.crt` ;
+                    ipa-getcert stop-tracking -f /tmp/server.crt ;
+                    ipa-getcert request -f /tmp/server.crt -k /tmp/server.key -g 4096 -N CN=myhost.example.com -K HTTP/myhost.example.com -D www.example.com -D myhost.example.com -F '/path/to/ca.crt'     -u digitalSignature -u nonRepudiation -u keyEncipherment -U id-kp-clientAuth -U id-kp-serverAuth -X 'ca-puppet' -T 'caIPAserviceCert' -B '/bin/systemctl stop httpd' -C '/bin/systemctl start httpd'"
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_exec('ipa-getcert-request-/tmp/server.crt').with_command(command) }
+  end
+end


### PR DESCRIPTION
This also fixes a bug in string splitting:

usage => 'digitalSignature, nonRepudiation, keyEncipherment'

Because the regsubst was not global it resulted in:

'-u digitalSignature -u nonRepudiation keyEncipherment'

Closes GH-7