### PR TITLE
Syntax error request_ipa_cert

### DIFF
--- a/manifests/request_ipa_cert.pp
+++ b/manifests/request_ipa_cert.pp
@@ -58,7 +58,7 @@ define certmonger::request_ipa_cert (
 
   if $keysize {
     $options_keysize = "-g ${keysize}"
-  else {
+  } else {
     $options_keysize = ''
   }
 


### PR DESCRIPTION
Could not parse for environment *root*: Syntax error at 'else' at request_ipa_cert.pp:61:3.