### PR TITLE
Add cacert file option to type/provider

### DIFF
--- a/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
+++ b/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
@@ -203,6 +203,10 @@ Puppet::Type.type(:certmonger_certificate).provide :certmonger_certificate do
       request_args << '-T'
       request_args << resource[:profile]
     end
+    if resource[:cacertfile]
+      request_args << '-F'
+      request_args << resource[:cacertfile]
+    end
     request_args
   end
 

--- a/lib/puppet/type/certmonger_certificate.rb
+++ b/lib/puppet/type/certmonger_certificate.rb
@@ -152,6 +152,10 @@ Puppet::Type.newtype(:certmonger_certificate) do
     desc 'ask the CA to process the request using the named profile.'
   end
 
+  newparam(:cacertfile) do
+    desc 'Persist the CA certificate in a file in the given path.'
+  end
+
   newparam(:force_resubmit) do
     desc 'If the request is found, force a resubmit operation.'
     defaultto false


### PR DESCRIPTION
As the cacert file option in the define, this persists the CA
certificate file in the given path. This addresses issue #5.