### PR TITLE
type/provider: Handle hostnames and IPs differently in dnsnames

### DIFF
--- a/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
+++ b/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
@@ -1,3 +1,5 @@
+require 'ipaddr'
+
 Puppet::Type.type(:certmonger_certificate).provide :certmonger_certificate do
   desc 'Provider for certmonger certificates.'
 
@@ -165,8 +167,15 @@ Puppet::Type.type(:certmonger_certificate).provide :certmonger_certificate do
                    resource[:dnsname]
                  end
       dnsarray.each do |dnsname|
-        request_args << '-D'
-        request_args << dnsname
+        begin
+          # We just call this to see if it's a valid IP
+          IPAddr.new(dnsname)
+          request_args << '-A'
+          request_args << dnsname
+        rescue ArgumentError
+          request_args << '-D'
+          request_args << dnsname
+        end
       end
     end
     if resource[:eku]


### PR DESCRIPTION
This detects if the given name is an IP address or a hostname and uses
the appropriate flag in the certmonger command. This way we can get
certificates with a valid SubjectAltName if we need to use an IP
address.