### PR TITLE
Add issuer option to type/provider

### DIFF
--- a/lib/puppet/type/certmonger_certificate.rb
+++ b/lib/puppet/type/certmonger_certificate.rb
@@ -107,6 +107,10 @@ Puppet::Type.newtype(:certmonger_certificate) do
     end
   end
 
+  newproperty(:issuer) do
+    desc 'The issuer name from which the certificate was requested.'
+  end
+
   newproperty(:hostname) do
     desc 'The hostname used in the CN for the certificate.'
   end

--- a/spec/unit/puppet/type/certmonger_certificate_spec.rb
+++ b/spec/unit/puppet/type/certmonger_certificate_spec.rb
@@ -381,5 +381,21 @@ describe Puppet::Type.type(:certmonger_certificate) do
         end.not_to raise_error
       end
     end
+
+    describe :issuer do
+      it 'has an issuer property' do
+        expect(
+          Puppet::Type.type(:certmonger_certificate).attrtype(:issuer)
+        ).to eq(:property)
+      end
+      it 'validates and pass if valid value' do
+        expect do
+          Puppet::Type.type(:certmonger_certificate).new(
+            name: name, ensure: :present, issuer: 'some_value'
+          )
+        end.not_to raise_error
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Adds an optional issuer, which can be used to target a FreeIPA sub-CA.