### PR TITLE
Restarting DBus before install certmonger

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,14 +1,18 @@
 # Class: certmonger
-class certmonger {
+class certmonger(
+  $manage_dbus_service = false
+) {
   # DBus package update from 7.4 to 7.5 breaks
   # The certmonger service, so dbus must get a
   # restart prior to start certmonger.
   # The official solution for dbus is either
   # restart the service, or reboot the machine
-  service { 'dbus':
-    ensure => running,
-    enable => true,
-    restart => '',
+  if $manage_dbus_service {
+    service { 'dbus':
+      ensure => running,
+      enable => true,
+      restart => '',
+    }
   }
 
   package { 'certmonger':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class certmonger(
       ensure => running,
       enable => true,
       restart => '',
+      notify => Service['certmonger'],
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,15 @@
 # Class: certmonger
 class certmonger {
+  # DBus package update from 7.4 to 7.5 breaks
+  # The certmonger service, so dbus must get a
+  # restart prior to start certmonger.
+  # The official solution for dbus is either
+  # restart the service, or reboot the machine
+  service { 'dbus':
+    ensure => running,
+    enable => true,
+    restart => '',
+  }
 
   package { 'certmonger':
     ensure => 'present',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,8 @@ class certmonger(
     service { 'dbus':
       ensure => running,
       enable => true,
-      restart => '',
+      hasstatus => true,
+      hasrestart => true,
       notify => Service['certmonger'],
     }
   }


### PR DESCRIPTION
If DBus is updated before run this module and the machine not get
restarted, the certmonger fails (among other services that relies
on dbus service).