### PR TITLE
provider: Update cert request on property change

### DIFF
--- a/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
+++ b/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
@@ -118,11 +118,9 @@ Puppet::Type.type(:certmonger_certificate).provide :certmonger_certificate do
       getcert(['stop-tracking', '-i', resource[:name]])
     else
       if !@property_hash.empty?
-        if resource[:force_resubmit]
-          request_args = ['resubmit', '-i', resource[:name]]
-          request_args.concat get_base_args(resource)
-          getcert request_args
-        end
+        request_args = ['resubmit', '-i', resource[:name]]
+        request_args.concat get_base_args(resource)
+        getcert request_args
       else
         request_args = ['request', '-I', resource[:name]]
         request_args.concat get_base_args(resource)

--- a/lib/puppet/type/certmonger_certificate.rb
+++ b/lib/puppet/type/certmonger_certificate.rb
@@ -157,7 +157,8 @@ Puppet::Type.newtype(:certmonger_certificate) do
   end
 
   newparam(:force_resubmit) do
-    desc 'If the request is found, force a resubmit operation.'
+    desc 'If the request is found, force a resubmit operation. (currently ' \
+         'not used)'
     defaultto false
     newvalues(true, false)
   end


### PR DESCRIPTION
It used to be the case that once you made a certificate request; if you
changed the resoruce in puppet, the cert request wouldn't be updated. It
relied on using the force_resubmit flag always, which is not ideal and
wasn't the intention. This is no longer the case with this change.

The force_resubmit flag should work when one doesn't actually change
properties from the resource, but still wants to issue a resubmit.
Currently we don't have that capability, but it will be added in the
future.

For now, making changes to the resource now works.

Change-Id: I2a682199299732adf31e9aed008ad6488d6f011c