### PR TITLE
Don't quote pre/post save commands

### DIFF
--- a/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
+++ b/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
@@ -189,11 +189,11 @@ Puppet::Type.type(:certmonger_certificate).provide :certmonger_certificate do
     end
     if resource[:presave_cmd]
       request_args << '-B'
-      request_args << "\"#{resource[:presave_cmd]}\""
+      request_args << "#{resource[:presave_cmd]}"
     end
     if resource[:postsave_cmd]
       request_args << '-C'
-      request_args << "\"#{resource[:postsave_cmd]}\""
+      request_args << "#{resource[:postsave_cmd]}"
     end
 
     request_args << '-w' if resource[:wait]


### PR DESCRIPTION
The arguments are passed to the command as a list, so the quoting was
not needed as one item in the list is taken as a single parameter.

This quoting broke post/pre save commands, so we gotta remove it to make
it work again.