### PR TITLE
Retry certificate request in case of failure

### DIFF
--- a/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
+++ b/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
@@ -1,5 +1,5 @@
 require 'ipaddr'
-require 'puppet/util/retryaction'
+require 'puppet/util/retry_action'
 
 Puppet::Type.type(:certmonger_certificate).provide :certmonger_certificate do
   desc 'Provider for certmonger certificates.'


### PR DESCRIPTION
This adds retry logic for the certificate request in case of failure.
This addresses intermittent issues, such as limited network connectivity.