### PR TITLE
Correctly populate principal during prefetch

### DIFF
--- a/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
+++ b/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
@@ -78,6 +78,8 @@ Puppet::Type.type(:certmonger_certificate).provide :certmonger_certificate do
         when %r{^\s+dns: .*}
           dns_raw = line.match(%r{dns: (.*)})[1]
           current_cert[:dnsname] = dns_raw.split(',')
+        when %r{^\s+principal name: .*}
+          current_cert[:principal] = line.match(%r{name: (.*)$})[1]
         when %r{^\s+eku: .*}
           eku_raw = line.match(%r{eku: (.*)})[1]
           current_cert[:eku] = eku_raw.split(',')


### PR DESCRIPTION
When retrieve information out of "get-cert list", we currently
miss the "principal name" information. Consequently, a prefetched
certificate resource always differ from its original definition
when it is created with a :principal property.

Parse the principal information during prefetch to retrieve the
entire state of certificate and prevent puppet from flushing the
resource and triggering unecessary resubmit actions.