### PR TITLE
Ability to get notified of resource change

### DIFF
--- a/lib/puppet/type/certmonger_certificate.rb
+++ b/lib/puppet/type/certmonger_certificate.rb
@@ -185,4 +185,8 @@ Puppet::Type.newtype(:certmonger_certificate) do
     defaultto false
     newvalues(true, false)
   end
+
+  def refresh
+    provider.flush()
+  end
 end


### PR DESCRIPTION
Make the type :certificate_certmonger able to react to
a notification sent by another puppet resource.

This is handy for requesting a new certificate to certmonger
when the content of the keyfile has changed (e.g. the user
generated another private key).