### PR TITLE
Fix comparison logic for key_size and eku

### DIFF
--- a/lib/puppet/type/certmonger_certificate.rb
+++ b/lib/puppet/type/certmonger_certificate.rb
@@ -121,6 +121,9 @@ Puppet::Type.newtype(:certmonger_certificate) do
 
   newproperty(:eku, array_matching: :all) do
     desc 'The Extended Key Usage OID\'s names used for the certificate.'
+    def insync?(is)
+      is.sort == should.sort
+    end
   end
 
   newproperty(:status) do
@@ -146,6 +149,9 @@ Puppet::Type.newtype(:certmonger_certificate) do
   newproperty(:key_size) do
     desc 'Size for the key used to generate the certificate.'
     defaultto '2048'
+    def insync?(is)
+      is.to_s == should.to_s
+    end
   end
 
   newproperty(:ca_error) do


### PR DESCRIPTION
eku is an array of values, which can be in any order.  The changes in this patch update the insync? method to reflect this so that spurious changes are not triggered.

key_size was added to allow callers to specify a key_size different from the default.  Unfortunately, getcert list does not provide the key_size output.  This results in a failing comparison every time.

To fix this, a mechanism is added to obtain the key_size by checking the key file with openssl.